### PR TITLE
feat: Update audio conversion settings to match requested specifications for bitrate, sample rate, and channel configuration

### DIFF
--- a/backend/src/infrastructure/storage/audio_blob_storage_client.py
+++ b/backend/src/infrastructure/storage/audio_blob_storage_client.py
@@ -127,9 +127,9 @@ class AudioBlobStorageClient:
                     output_options = {
                         'vn': None,  # No video
                         'c:a': 'aac',  # AAC audio codec for MP4
-                        'b:a': '128k',  # Audio bitrate
-                        'ar': 44100,  # Sample rate
-                        'ac': 2,  # Stereo channels
+                        'b:a': '127k',  # Audio bitrate - 127 kbps as requested
+                        'ar': 32000,  # Sample rate - 32 kHz as requested
+                        'ac': 1,  # Mono channel as requested
                         'f': 'mp4',  # Force MP4 format
                         'movflags': 'frag_keyframe+empty_moov'  # Better MP4 compatibility
                     }
@@ -139,9 +139,9 @@ class AudioBlobStorageClient:
                     output_options = {
                         'vn': None,  # No video
                         'c:a': 'aac',  # AAC audio codec for MP4
-                        'b:a': '128k',  # Audio bitrate
-                        'ar': 44100,  # Sample rate
-                        'ac': 2,  # Stereo channels
+                        'b:a': '127k',  # Audio bitrate - 127 kbps as requested
+                        'ar': 32000,  # Sample rate - 32 kHz as requested
+                        'ac': 1,  # Mono channel as requested
                         'f': 'mp4'  # Force MP4 format
                     }
                 


### PR DESCRIPTION
This pull request updates the audio conversion settings in the `_convert_to_mp4_with_ffmpeg` method of the `audio_blob_storage_client.py` file. The changes adjust the audio bitrate, sample rate, and channel configuration to meet new requirements.

Audio conversion settings update:

* [`backend/src/infrastructure/storage/audio_blob_storage_client.py`](diffhunk://#diff-c904c85aa617daf02e2ba34b90457658f4cef9695c61c9b97446002da290b117L130-R132): Changed audio bitrate from `128k` to `127k`, sample rate from `44100` Hz to `32000` Hz, and channel configuration from stereo (`ac: 2`) to mono (`ac: 1`). These modifications align with the requested specifications. [[1]](diffhunk://#diff-c904c85aa617daf02e2ba34b90457658f4cef9695c61c9b97446002da290b117L130-R132) [[2]](diffhunk://#diff-c904c85aa617daf02e2ba34b90457658f4cef9695c61c9b97446002da290b117L142-R144)